### PR TITLE
Updated OSRM references to version 5.0.0 for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,22 @@ RUN apt-get -y update && apt-get install -y \
     libluabind-dev \
     libluajit-5.1-dev \
     pkg-config
-    
-RUN mkdir -p /osrm-src \
- && mkdir -p /osrm-build \
+
+RUN mkdir -p /osrm-build \
  && mkdir -p /osrm-data
- 
+
 WORKDIR /osrm-build
 
-RUN git clone https://github.com/DennisOSRM/Project-OSRM.git /osrm-src \
+RUN curl --silent -L https://github.com/Project-OSRM/osrm-backend/archive/v5.0.0.tar.gz -o v5.0.0.tar.gz \
+ && tar xzf v5.0.0.tar.gz \
+ && mv osrm-backend-5.0.0 /osrm-src \
  && cmake /osrm-src \
  && make \
  && mv /osrm-src/profiles/car.lua profile.lua \
  && mv /osrm-src/profiles/lib/ lib \
  && echo "disk=/tmp/stxxl,25000,syscall" > .stxxl \
  && rm -rf /osrm-src
- 
+
 # Cleanup --------------------------------
 
 RUN apt-get clean \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,16 +7,15 @@ _sig() {
 
 if [ "$1" = 'osrm' ]; then
   trap _sig SIGKILL SIGTERM SIGHUP SIGINT EXIT
-  
+
   if [ ! -f $DATA_PATH/$2.osrm ]; then
     if [ ! -f $DATA_PATH/$2.osm.pbf ]; then
       curl $3 > $DATA_PATH/$2.osm.pbf
     fi
     ./osrm-extract $DATA_PATH/$2.osm.pbf
-    ./osrm-prepare $DATA_PATH/$2.osrm
-    rm $DATA_PATH/$2.osm.pbf
+    ./osrm-contract $DATA_PATH/$2.osrm
   fi
-  
+
   ./osrm-routed $DATA_PATH/$2.osrm --max-table-size 8000 &
   child=$!
   wait "$child"


### PR DESCRIPTION
Summary of changes:
- ./osrm-prepare is now named ./osrm-extract (as described in v5 changelog)
- Not deleting osm.pbf file (which might have been downloaded already, or read from shared volume)
- Explicit version number instead of master branch

Note that the OSRM frontend docker image is not updated yet to support v5, so the "start" example will not work.
