### PR TITLE
Fixes entry point according to Project-OSRM/osrm-backend@8feb300d15

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,16 +7,16 @@ _sig() {
 
 if [ "$1" = 'osrm' ]; then
   trap _sig SIGKILL SIGTERM SIGHUP SIGINT EXIT
-  
+
   if [ ! -f $DATA_PATH/$2.osrm ]; then
     if [ ! -f $DATA_PATH/$2.osm.pbf ]; then
       curl $3 > $DATA_PATH/$2.osm.pbf
     fi
-    ./osrm-extract $DATA_PATH/$2.osm.pbf
-    ./osrm-prepare $DATA_PATH/$2.osrm
-    rm $DATA_PATH/$2.osm.pbf
+     ./osrm-extract $DATA_PATH/$2.osm.pbf
+     ./osrm-contract $DATA_PATH/$2.osrm
+     rm $DATA_PATH/$2.osm.pbf
   fi
-  
+
   ./osrm-routed $DATA_PATH/$2.osrm --max-table-size 8000 &
   child=$!
   wait "$child"


### PR DESCRIPTION
Hello! In the 5.0.0 release the `osrm-prepare` was renamed to `osrm-contract`. Thus, the current entrypoint calls for a script that doesn't exist. This commits corrects that issue.

Changelog https://github.com/Project-OSRM/osrm-backend/blob/master/CHANGELOG.md

For fast testing I recomend Delaware!

```
docker run -p 5000:5000 7c588 osrm delaware http://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf
```

With help from @aescobedob
